### PR TITLE
Initialize Hono backend

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "hono-backend",
+  "version": "1.0.0",
+  "description": "Backend server using Hono framework",
+  "main": "dist/index.js",
+  "scripts": {
+    "start": "node dist/index.js",
+    "dev": "tsx src/index.ts",
+    "build": "tsc",
+    "test": "tsx test/index.test.ts"
+  },
+  "dependencies": {
+    "hono": "^3.11.0",
+    "@hono/node-server": "^1.4.0"
+  },
+  "devDependencies": {
+    "tsx": "^3.12.7",
+    "typescript": "^5.4.5"
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,15 @@
+import { Hono } from 'hono';
+import { serve } from '@hono/node-server';
+
+// Export the app so it can be tested without starting the server
+export const app = new Hono();
+
+app.get('/', (c) => c.text('Hello from Hono!'));
+
+// Only start the server when this file is executed directly
+if (import.meta.main) {
+  serve({
+    fetch: app.fetch,
+    port: 3000,
+  });
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,0 +1,13 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { app } from '../src/index';
+
+describe('GET /', () => {
+  it('returns greeting', async () => {
+    const res = await app.request('/');
+    const body = await res.text();
+    assert.equal(body, 'Hello from Hono!');
+  });
+});
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- export Hono app so it can be tested without starting the server
- add basic test verifying root endpoint greeting
- wire up `npm test` to run the new TypeScript test

## Testing
- `npm install` (fails: 403 Forbidden to registry)
- `npm test` (fails: tsx not found)


------
https://chatgpt.com/codex/tasks/task_e_68a00b244bc4832b91ee90dca8c39563